### PR TITLE
Support new API format

### DIFF
--- a/src/Search.ts
+++ b/src/Search.ts
@@ -3,29 +3,42 @@ import * as vscode from 'vscode';
 import ExtensionConfig from './utils/ExtensionConfig';
 import { Inject } from 'typescript-ioc';
 import IStorage from './api/storage/IStorage';
+import { IApiReferenceIndexSymbol } from './api/IApiReference';
+
+interface ApiItem extends vscode.QuickPickItem{
+	name:string;
+}
+
+const expand=(items:IApiReferenceIndexSymbol[],prefix="")=>
+	items.reduce((acc: ApiItem[], cur) => {
+		const label = (prefix&&cur.name.substr(0,prefix.length)!==prefix
+			?`${prefix}.`:
+			"")+cur.name;
+		if(cur.name!==prefix) {
+			acc.push({label,description:cur.lib,name:cur.name});
+		}
+		if(cur.nodes) {acc.push(...expand(cur.nodes,label));}
+		return acc;
+	}, []);
+
 
 export default class Search {
 	@Inject private storage!: IStorage;
 
 	public async run(): Promise<void> {
-		let items = (await this.storage.getApiIndex()).symbols;
+		let items = expand((await this.storage.getApiIndex()).symbols);
 
 		vscode.window.showQuickPick(
-			items.map(item => {
-				return {
-					label: item.name,
-					description: item.lib
-				};
-			}), {
+			items, {
 				canPickMany: false,
 				placeHolder: "Start typing..."
 			}
 		).then(selected => this.searchResultHandler(selected));
 	}
 
-	private searchResultHandler(result: vscode.QuickPickItem | undefined) {
+	private searchResultHandler(result: ApiItem | undefined) {
 		if (result) {
-			vscode.commands.executeCommand(ExtensionConfig.Commands.Render, result.label);
+			vscode.commands.executeCommand(ExtensionConfig.Commands.Render, result.name);
 		}
 	}
 }

--- a/src/api/IApiReference.ts
+++ b/src/api/IApiReference.ts
@@ -30,7 +30,7 @@ export interface IApiReferenceIndexSymbol {
 	displayName: string;
 	bIsDeprecated: boolean;
 	extends?: string;
-	nodes:IApiReferenceIndexSymbol[];
+	nodes?:IApiReferenceIndexSymbol[];
 	implements?: string[];
 	extendedBy?: string[];
 	implementedBy?: string[];

--- a/src/api/IApiReference.ts
+++ b/src/api/IApiReference.ts
@@ -27,12 +27,14 @@ export interface IApiReferenceIndexSymbol {
 	kind: SymbolKind;
 	visibility: SymbolVisibility;
 	lib: string;
+	displayName: string;
+	bIsDeprecated: boolean;
 	extends?: string;
+	nodes:IApiReferenceIndexSymbol[];
 	implements?: string[];
 	extendedBy?: string[];
 	implementedBy?: string[];
 }
-
 /******* Api Library *******/
 
 export interface IApiReferenceLibrary {

--- a/src/tree/ApiTreeDataProvider.ts
+++ b/src/tree/ApiTreeDataProvider.ts
@@ -100,7 +100,10 @@ export default class ApiTreeDataProvider implements vscode.TreeDataProvider<ApiT
 			name: label,
 			kind: SymbolKind.Namespace,
 			lib: "",
-			visibility: SymbolVisibility.Public
+			visibility: SymbolVisibility.Public,
+			displayName:label,
+			bIsDeprecated:false,
+			nodes:[]
 		});
 
 		item.wrapperOnly = true;

--- a/src/tree/ApiTreeItem.ts
+++ b/src/tree/ApiTreeItem.ts
@@ -26,6 +26,9 @@ export default class ApiTreeItem extends vscode.TreeItem {
 
 	public update(): ApiTreeItem {
 		this.id = this.symbol.name;
+		if(this.symbol&&this.symbol.nodes){
+			this.children = this.symbol.nodes.map(n=>new ApiTreeItem(n));
+		}
 		this.label = this.IsRoot ? this.symbol.name : this.symbol.name.replace(`${this.parent.symbol.name}.`, "");
 		this.collapsibleState = this.HasChildren ? vscode.TreeItemCollapsibleState.Collapsed : vscode.TreeItemCollapsibleState.None;
 

--- a/src/view/PanelsManager.ts
+++ b/src/view/PanelsManager.ts
@@ -5,6 +5,19 @@ import IStorage from "../api/storage/IStorage";
 import { Inject } from "typescript-ioc";
 import IPanelRenderer from "./IPanelRenderer";
 
+const findNode = (
+	  root:IApiReferenceIndexSymbol,
+	  name:string
+	):IApiReferenceIndexSymbol|undefined=>{
+		if(!root.nodes) {return;}
+		let found = root.nodes.find(s => s.name === name);
+		if (found){return found;}
+		for(const n of root.nodes){
+			found = findNode(n,name);
+			if (found){return found;}
+		}
+};
+
 export default class PanelsManager {
 	private panels: {
 		[key: string]: vscode.WebviewPanel
@@ -16,8 +29,13 @@ export default class PanelsManager {
 	public async show(item: string | IApiReferenceIndexSymbol) {
 		if (typeof item === "string") {
 			let index = await this.apiStorage.getApiIndex();
+			let symbol;
+			for(const root of index.symbols){
+				symbol = findNode(root,item);
+				if(symbol){break;}
+			}
 
-			this.showInternal(index.symbols.find(s => s.name === item) as IApiReferenceIndexSymbol);
+			if(symbol){this.showInternal(symbol);}
 		} else {
 			this.showInternal(item);
 		}


### PR DESCRIPTION
Not sure how the old format looked like, but now the API file is like the one below

This change is the bare minimum to get it work again, not sure I fully understood how it's supposed to work (and I process all children recursively just because it's easy)

```json
{
    "$schema-ref": "http://schemas.sap.com/sapui5/designtime/api-index.json/1.0",
    "version": "1.64.0",
    "library": "*",
    "symbols": [
        {
            "name": "sap",
            "kind": "namespace",
            "visibility": "public",
            "lib": "sap.ui.core",
            "displayName": "sap",
            "bIsDeprecated": false,
            "nodes": [
                {
                    "name": "sap.base",
                    "displayName": "base",
                    "lib": "sap.ui.core",
                    "kind": "namespace",
                    "visibility": "public",
                    "bIsDeprecated": false,
                    "nodes": []
                }
            ]
        }
    ]
}
```
On the bright side, it seems to work:
![image](https://user-images.githubusercontent.com/2453277/57588869-0928ad80-7513-11e9-855b-0cd62e990af3.png)
